### PR TITLE
ONEHUB-150 Include erb files when gathering files to parse comments

### DIFF
--- a/lib/kss/parser.rb
+++ b/lib/kss/parser.rb
@@ -19,7 +19,7 @@ module Kss
         if Dir.exists?(path_or_string)
           # argument is a path
           path = path_or_string
-          Dir["#{path}/**/*.{css,less,sass,scss}"].each do |filename|
+          Dir["#{path}/**/*.{css,less,sass,scss,erb}"].each do |filename|
             parser = CommentParser.new(filename)
             parser.blocks.each do |comment_block|
               add_section comment_block, filename if self.class.kss_block?(comment_block)


### PR DESCRIPTION
## Description

Our styleguide documentation parses stylesheet files to grab comments and generate pages of documentation. During the redesign work, the icons scss file got renamed to have an `erb` extension (`app/assets/stylesheets/modules/_icons.scss.erb`).

This PR alters the parser to also look for erb files.

### Dev notes
* The doppio gemfile uses the `add-path-to-sections` branch: https://github.com/onehub/doppio/blob/8764-redesign-epic/Gemfile#L43

Before

![image](https://github.com/user-attachments/assets/1271233c-4d6d-4ef7-bae1-616e4af6b19f)

After

![image](https://github.com/user-attachments/assets/13e27788-5687-49ae-8b69-69fe34d43e87)
