### PR TITLE
Update kss to be compatible with ruby 3.2.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ SPEC.md
 docker-bake.hcl
 example
 test-all-rubies.sh
+coverage/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,12 @@
+.bundle
+.git
+.github
+Dockerfile*
 Gemfile.lock
+Knylefile
+LICENSE
+README.md
+SPEC.md
+docker-bake.hcl
+example
+test-all-rubies.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,10 @@ jobs:
           - "3.4"
           - "4.0"
           - head
+        coverage: [0]
         include:
+          - ruby: "4.0"
+            coverage: 1
           - ruby: head
             allow_failure: true
     steps:
@@ -42,7 +45,7 @@ jobs:
         env:
           RUBY: ${{ matrix.ruby }}
       - name: Test
-        run: docker run --rm "kss-test:${{ matrix.ruby }}"
+        run: docker run --rm -e COVERAGE=${{ matrix.coverage }} "kss-test:${{ matrix.ruby }}"
 
   gate:
     name: All Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow_failure || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "1.9"
+          - "2.0"
+          - "2.1"
+          - "2.2"
+          - "2.3"
+          - "2.4"
+          - "2.5"
+          - "2.6"
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "4.0"
+          - head
+        include:
+          - ruby: head
+            allow_failure: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build
+        run: docker buildx bake --load "ruby-${RUBY//\./-}"
+        env:
+          RUBY: ${{ matrix.ruby }}
+      - name: Test
+        run: docker run --rm "kss-test:${{ matrix.ruby }}"
+
+  gate:
+    name: All Tests
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-slim
+    steps:
+      - if: ${{ !success() }}
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 bin
 .sass-cache
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: ruby
-rvm:
-  - 2.0.0
-  - 1.9.3
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,10 @@ RUN if [ -n "$INSTALL_BUNDLER" ]; then \
 WORKDIR /app
 COPY . .
 
-RUN bundle install --jobs $(nproc)
+RUN --mount=type=cache,target=/bundle-cache \
+    bundle config set --local path /bundle-cache \
+    && (bundle check || bundle install --jobs $(nproc)) \
+    && mkdir -p vendor/bundle \
+    && cp -a /bundle-cache/* vendor/bundle/ \
+    && bundle config set --local path vendor/bundle
 CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+FROM debian:bullseye
+
+RUN apt-get update && apt-get install -y \
+    autotools-dev build-essential curl ca-certificates \
+    libssl-dev libreadline-dev libffi-dev libyaml-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG OPENSSL=1.0.2
+# Build OpenSSL 1.0.2 only when needed (Ruby <2.4 is incompatible with OpenSSL 1.1+)
+RUN if [ "$OPENSSL" = "1.0.2" ]; then \
+    curl -fSL https://www.openssl.org/source/openssl-1.0.2u.tar.gz | tar -xzC /usr/local/src \
+    && cd /usr/local/src/openssl-1.0.2u \
+    && ./config --prefix=/opt/openssl-1.0.2 shared \
+    && make -j"$(nproc)" \
+    && make install_sw \
+    && rm -rf /usr/local/src/openssl-1.0.2u; \
+    fi
+
+ARG RUBY_MAJOR=1.9
+ARG RUBY_VERSION=1.9.3-p551
+ARG RUBY_ARCHIVE=bz2
+
+# Download and extract Ruby source
+RUN mkdir -p /usr/local/src/ruby \
+    && curl -fSL "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-${RUBY_VERSION}.tar.${RUBY_ARCHIVE}" \
+        | tar -x$([ "$RUBY_ARCHIVE" = "bz2" ] && echo j || echo z)C /usr/local/src/ruby --strip-components=1
+
+# Patch config.guess/config.sub for aarch64 support, then compile
+RUN cp /usr/share/misc/config.guess /usr/local/src/ruby/tool/ \
+    && cp /usr/share/misc/config.sub /usr/local/src/ruby/tool/ \
+    && cd /usr/local/src/ruby \
+    && OPENSSL_DIR=$([ "$OPENSSL" = "1.0.2" ] && echo /opt/openssl-1.0.2 || echo /usr) \
+    && ./configure --prefix=/opt/rubies/ruby-${RUBY_VERSION} --disable-install-doc \
+        --with-openssl-dir=$OPENSSL_DIR \
+    && if [ "$(printf '%s\n' "2.5" "$RUBY_MAJOR" | sort -V | head -n1)" = "2.5" ]; then \
+         make -j"$(nproc)"; \
+       else \
+         make; \
+       fi \
+    && make install \
+    && rm -rf /usr/local/src/ruby
+
+ENV PATH=/opt/rubies/ruby-${RUBY_VERSION}/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/openssl-1.0.2/lib
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+ARG INSTALL_BUNDLER=1.17.3
+RUN if [ -n "$INSTALL_BUNDLER" ]; then \
+    gem install bundler -v $INSTALL_BUNDLER --no-document 2>/dev/null \
+    || gem install bundler -v $INSTALL_BUNDLER --no-rdoc --no-ri; \
+    fi
+
+WORKDIR /app
+COPY . .
+
+RUN bundle install --jobs $(nproc)
+CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,11 @@ WORKDIR /app
 COPY . .
 
 RUN --mount=type=cache,target=/bundle-cache \
-    bundle config set --local path /bundle-cache \
+    (bundle config set --local path /bundle-cache 2>/dev/null \
+      || bundle config --local path /bundle-cache) \
     && (bundle check || bundle install --jobs $(nproc)) \
     && mkdir -p vendor/bundle \
-    && cp -a /bundle-cache/* vendor/bundle/ \
-    && bundle config set --local path vendor/bundle
+    && cp -a /bundle-cache/. vendor/bundle/ \
+    && (bundle config set --local path vendor/bundle 2>/dev/null \
+      || bundle config --local path vendor/bundle)
 CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile.head
+++ b/Dockerfile.head
@@ -1,0 +1,31 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt-get install -y \
+    autotools-dev autoconf bison build-essential curl ca-certificates git \
+    ruby \
+    libssl-dev libreadline-dev libffi-dev libyaml-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/ruby/ruby.git /usr/local/src/ruby \
+    && cd /usr/local/src/ruby \
+    && ./autogen.sh \
+    && cp /usr/share/misc/config.guess tool/ \
+    && cp /usr/share/misc/config.sub tool/ \
+    && ./configure --prefix=/opt/rubies/ruby-head --disable-install-doc \
+    && make -j"$(nproc)" \
+    && make install \
+    && rm -rf /usr/local/src/ruby
+
+ENV PATH=/opt/rubies/ruby-head/bin:$PATH
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+COPY . .
+
+RUN --mount=type=cache,target=/bundle-cache \
+    bundle config set --local path /bundle-cache \
+    && (bundle check || bundle install --jobs $(nproc)) \
+    && mkdir -p vendor/bundle \
+    && cp -a /bundle-cache/* vendor/bundle/ \
+    && bundle config set --local path vendor/bundle
+CMD ["bundle", "exec", "rake", "test"]

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
     gem "minitest", "~> 5.0.4"
   end
   gem "test-unit" unless RUBY_VERSION < "2.0"
+  gem "simplecov", require: false if RUBY_VERSION >= "2.4"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,20 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "minitest", "~> 5.0.4"
+  if RUBY_VERSION >= "4.0"
+    gem "minitest", "~> 6.0"
+  elsif RUBY_VERSION >= "3.4"
+    gem "minitest", "~> 5.25"
+  else
+    gem "minitest", "~> 5.0.4"
+  end
   gem "test-unit" unless RUBY_VERSION < "2.0"
 end
 
 group :development do
-  gem "mg", ">= 0.0.8"
   if RUBY_VERSION < "2.3"
     gem "rake", "~> 12.0"
   else
     gem "rake", "~> 13.0"
   end
-  gem "rubyforge", ">= 2.0.3"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,16 @@
-source :rubygems
+source "https://rubygems.org"
 
 group :test do
-  gem "minitest", ">= 1.5.0"
+  gem "minitest", "~> 4.0"
+  gem "test-unit" unless RUBY_VERSION < "2.0"
 end
 
 group :development do
   gem "mg", ">= 0.0.8"
-  gem "rake", ">= 0.8.7"
+  if RUBY_VERSION < "2.3"
+    gem "rake", "~> 12.0"
+  else
+    gem "rake", "~> 13.0"
+  end
   gem "rubyforge", ">= 2.0.3"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -34,23 +34,3 @@ task :console do
   exec "irb -I lib -rkss"
 end
 
-#
-# Gems
-#
-
-begin
-  require 'mg'
-  MG.new("kss.gemspec")
-rescue LoadError
-  warn "mg not available."
-  warn "Install it with: gem install mg"
-end
-
-desc "Push a new version to Gemcutter and publish docs."
-task :publish => "gem:publish" do
-  require File.dirname(__FILE__) + '/lib/kss/version'
-
-  sh "git tag v#{Kss::VERSION}"
-  sh "git push origin master --tags"
-  sh "git clean -fd"
-end

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,6 +35,7 @@ group "default" {
     "ruby-3-3",
     "ruby-3-4",
     "ruby-4-0",
+    "ruby-head",
   ]
 }
 
@@ -221,4 +222,10 @@ target "ruby-4-0" {
     INSTALL_BUNDLER = VERSIONS["4.0"].bundler
   }
   tags = ["kss-test:4.0"]
+}
+
+target "ruby-head" {
+  dockerfile = "Dockerfile.head"
+  context    = "."
+  tags       = ["kss-test:head"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,224 @@
+variable "VERSIONS" {
+  default = {
+    "1.9" = { version = "1.9.3-p551", archive = "bz2", openssl = "1.0.2", bundler = "1.17.3" }
+    "2.0" = { version = "2.0.0-p648", archive = "bz2", openssl = "1.0.2", bundler = "1.17.3" }
+    "2.1" = { version = "2.1.10",     archive = "bz2", openssl = "1.0.2", bundler = "1.17.3" }
+    "2.2" = { version = "2.2.10",     archive = "bz2", openssl = "1.0.2", bundler = "1.17.3" }
+    "2.3" = { version = "2.3.8",      archive = "bz2", openssl = "1.0.2", bundler = "1.17.3" }
+    "2.4" = { version = "2.4.10",     archive = "bz2", openssl = "1.1",   bundler = "1.17.3" }
+    "2.5" = { version = "2.5.9",      archive = "bz2", openssl = "1.1",   bundler = "1.17.3" }
+    "2.6" = { version = "2.6.10",     archive = "bz2", openssl = "1.1",   bundler = "1.17.3" }
+    "2.7" = { version = "2.7.8",      archive = "bz2", openssl = "1.1",   bundler = "" }
+    "3.0" = { version = "3.0.7",      archive = "gz",  openssl = "1.1",   bundler = "" }
+    "3.1" = { version = "3.1.7",      archive = "gz",  openssl = "1.1",   bundler = "" }
+    "3.2" = { version = "3.2.10",     archive = "gz",  openssl = "1.1",   bundler = "" }
+    "3.3" = { version = "3.3.10",     archive = "gz",  openssl = "1.1",   bundler = "" }
+    "3.4" = { version = "3.4.8",      archive = "gz",  openssl = "1.1",   bundler = "" }
+    "4.0" = { version = "4.0.1",      archive = "gz",  openssl = "1.1",   bundler = "" }
+  }
+}
+
+group "default" {
+  targets = [
+    "ruby-1-9",
+    "ruby-2-0",
+    "ruby-2-1",
+    "ruby-2-2",
+    "ruby-2-3",
+    "ruby-2-4",
+    "ruby-2-5",
+    "ruby-2-6",
+    "ruby-2-7",
+    "ruby-3-0",
+    "ruby-3-1",
+    "ruby-3-2",
+    "ruby-3-3",
+    "ruby-3-4",
+    "ruby-4-0",
+  ]
+}
+
+target "_common" {
+  dockerfile = "Dockerfile"
+  context    = "."
+}
+
+target "ruby-1-9" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "1.9"
+    RUBY_VERSION   = VERSIONS["1.9"].version
+    RUBY_ARCHIVE   = VERSIONS["1.9"].archive
+    OPENSSL        = VERSIONS["1.9"].openssl
+    INSTALL_BUNDLER = VERSIONS["1.9"].bundler
+  }
+  tags = ["kss-test:1.9"]
+}
+
+target "ruby-2-0" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.0"
+    RUBY_VERSION   = VERSIONS["2.0"].version
+    RUBY_ARCHIVE   = VERSIONS["2.0"].archive
+    OPENSSL        = VERSIONS["2.0"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.0"].bundler
+  }
+  tags = ["kss-test:2.0"]
+}
+
+target "ruby-2-1" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.1"
+    RUBY_VERSION   = VERSIONS["2.1"].version
+    RUBY_ARCHIVE   = VERSIONS["2.1"].archive
+    OPENSSL        = VERSIONS["2.1"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.1"].bundler
+  }
+  tags = ["kss-test:2.1"]
+}
+
+target "ruby-2-2" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.2"
+    RUBY_VERSION   = VERSIONS["2.2"].version
+    RUBY_ARCHIVE   = VERSIONS["2.2"].archive
+    OPENSSL        = VERSIONS["2.2"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.2"].bundler
+  }
+  tags = ["kss-test:2.2"]
+}
+
+target "ruby-2-3" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.3"
+    RUBY_VERSION   = VERSIONS["2.3"].version
+    RUBY_ARCHIVE   = VERSIONS["2.3"].archive
+    OPENSSL        = VERSIONS["2.3"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.3"].bundler
+  }
+  tags = ["kss-test:2.3"]
+}
+
+target "ruby-2-4" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.4"
+    RUBY_VERSION   = VERSIONS["2.4"].version
+    RUBY_ARCHIVE   = VERSIONS["2.4"].archive
+    OPENSSL        = VERSIONS["2.4"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.4"].bundler
+  }
+  tags = ["kss-test:2.4"]
+}
+
+target "ruby-2-5" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.5"
+    RUBY_VERSION   = VERSIONS["2.5"].version
+    RUBY_ARCHIVE   = VERSIONS["2.5"].archive
+    OPENSSL        = VERSIONS["2.5"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.5"].bundler
+  }
+  tags = ["kss-test:2.5"]
+}
+
+target "ruby-2-6" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.6"
+    RUBY_VERSION   = VERSIONS["2.6"].version
+    RUBY_ARCHIVE   = VERSIONS["2.6"].archive
+    OPENSSL        = VERSIONS["2.6"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.6"].bundler
+  }
+  tags = ["kss-test:2.6"]
+}
+
+target "ruby-2-7" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "2.7"
+    RUBY_VERSION   = VERSIONS["2.7"].version
+    RUBY_ARCHIVE   = VERSIONS["2.7"].archive
+    OPENSSL        = VERSIONS["2.7"].openssl
+    INSTALL_BUNDLER = VERSIONS["2.7"].bundler
+  }
+  tags = ["kss-test:2.7"]
+}
+
+target "ruby-3-0" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "3.0"
+    RUBY_VERSION   = VERSIONS["3.0"].version
+    RUBY_ARCHIVE   = VERSIONS["3.0"].archive
+    OPENSSL        = VERSIONS["3.0"].openssl
+    INSTALL_BUNDLER = VERSIONS["3.0"].bundler
+  }
+  tags = ["kss-test:3.0"]
+}
+
+target "ruby-3-1" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "3.1"
+    RUBY_VERSION   = VERSIONS["3.1"].version
+    RUBY_ARCHIVE   = VERSIONS["3.1"].archive
+    OPENSSL        = VERSIONS["3.1"].openssl
+    INSTALL_BUNDLER = VERSIONS["3.1"].bundler
+  }
+  tags = ["kss-test:3.1"]
+}
+
+target "ruby-3-2" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "3.2"
+    RUBY_VERSION   = VERSIONS["3.2"].version
+    RUBY_ARCHIVE   = VERSIONS["3.2"].archive
+    OPENSSL        = VERSIONS["3.2"].openssl
+    INSTALL_BUNDLER = VERSIONS["3.2"].bundler
+  }
+  tags = ["kss-test:3.2"]
+}
+
+target "ruby-3-3" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "3.3"
+    RUBY_VERSION   = VERSIONS["3.3"].version
+    RUBY_ARCHIVE   = VERSIONS["3.3"].archive
+    OPENSSL        = VERSIONS["3.3"].openssl
+    INSTALL_BUNDLER = VERSIONS["3.3"].bundler
+  }
+  tags = ["kss-test:3.3"]
+}
+
+target "ruby-3-4" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "3.4"
+    RUBY_VERSION   = VERSIONS["3.4"].version
+    RUBY_ARCHIVE   = VERSIONS["3.4"].archive
+    OPENSSL        = VERSIONS["3.4"].openssl
+    INSTALL_BUNDLER = VERSIONS["3.4"].bundler
+  }
+  tags = ["kss-test:3.4"]
+}
+
+target "ruby-4-0" {
+  inherits = ["_common"]
+  args = {
+    RUBY_MAJOR     = "4.0"
+    RUBY_VERSION   = VERSIONS["4.0"].version
+    RUBY_ARCHIVE   = VERSIONS["4.0"].archive
+    OPENSSL        = VERSIONS["4.0"].openssl
+    INSTALL_BUNDLER = VERSIONS["4.0"].bundler
+  }
+  tags = ["kss-test:4.0"]
+}

--- a/kss.gemspec
+++ b/kss.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.homepage          = "http://github.com/kneath/kss"
   s.email             = "kneath@gmail.com"
   s.authors           = [ "Kyle Neath" ]
-  s.has_rdoc          = false
   s.license           = "MIT"
 
   s.files             = %w( README.md Rakefile LICENSE )

--- a/lib/kss/comment_parser.rb
+++ b/lib/kss/comment_parser.rb
@@ -66,6 +66,8 @@ module Kss
     def initialize(file_path_or_string_input, options={})
       @options = options
       @options[:preserve_whitespace] = false if @options[:preserve_whitespace].nil?
+      @file_path = nil
+      @string_input = nil
       if File.exist?(file_path_or_string_input)
         @file_path = file_path_or_string_input
       else

--- a/lib/kss/comment_parser.rb
+++ b/lib/kss/comment_parser.rb
@@ -66,7 +66,7 @@ module Kss
     def initialize(file_path_or_string_input, options={})
       @options = options
       @options[:preserve_whitespace] = false if @options[:preserve_whitespace].nil?
-      if File.exists?(file_path_or_string_input)
+      if File.exist?(file_path_or_string_input)
         @file_path = file_path_or_string_input
       else
         @string_input = file_path_or_string_input

--- a/lib/kss/parser.rb
+++ b/lib/kss/parser.rb
@@ -16,7 +16,7 @@ module Kss
       @sections = {}
 
       paths_or_strings.each do |path_or_string|
-        if Dir.exists?(path_or_string)
+        if Dir.exist?(path_or_string)
           # argument is a path
           path = path_or_string
           Dir["#{path}/**/*.{css,less,sass,scss,erb}"].each do |filename|

--- a/lib/kss/section.rb
+++ b/lib/kss/section.rb
@@ -18,6 +18,7 @@ module Kss
     def initialize(comment_text=nil, filename=nil)
       @raw = comment_text
       @filename = filename
+      @section = nil
     end
 
     # Splits up the raw comment text into comment sections that represent

--- a/test-all-rubies.sh
+++ b/test-all-rubies.sh
@@ -4,22 +4,8 @@ set -e
 echo "Building all Ruby versions..."
 docker buildx bake
 
-failed=""
-for tag in 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 4.0; do
-  echo ""
-  echo "=== Ruby $tag ==="
-  if docker run --rm "kss-test:$tag"; then
-    echo "--- Ruby $tag: PASS ---"
-  else
-    echo "--- Ruby $tag: FAIL ---"
-    failed="$failed $tag"
-  fi
-done
-
 echo ""
-if [ -n "$failed" ]; then
-  echo "FAILED:$failed"
-  exit 1
-else
-  echo "All versions passed."
-fi
+echo "Running tests..."
+parallel --will-cite --tag --tagstring "Ruby {}" --line-buffer \
+  docker run --rm "kss-test:{}" \
+  ::: 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 4.0 head

--- a/test-all-rubies.sh
+++ b/test-all-rubies.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+echo "Building all Ruby versions..."
+docker buildx bake
+
+failed=""
+for tag in 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 4.0; do
+  echo ""
+  echo "=== Ruby $tag ==="
+  if docker run --rm "kss-test:$tag"; then
+    echo "--- Ruby $tag: PASS ---"
+  else
+    echo "--- Ruby $tag: FAIL ---"
+    failed="$failed $tag"
+  fi
+done
+
+echo ""
+if [ -n "$failed" ]; then
+  echo "FAILED:$failed"
+  exit 1
+else
+  echo "All versions passed."
+fi

--- a/test-all-rubies.sh
+++ b/test-all-rubies.sh
@@ -6,6 +6,7 @@ docker buildx bake
 
 echo ""
 echo "Running tests..."
-parallel --will-cite --tag --tagstring "Ruby {}" --line-buffer \
-  docker run --rm "kss-test:{}" \
-  ::: 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 4.0 head
+parallel --will-cite --tag --tagstring "Ruby {1}" --line-buffer \
+  docker run --rm -e COVERAGE={2} "kss-test:{1}" \
+  ::: 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 4.0 head \
+  :::+ 0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,11 @@
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    enable_coverage :branch
+    add_filter "/test/"
+  end
+end
+
 require 'minitest/autorun'
 require 'kss'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,4 @@
-if ENV["COVERAGE"]
+if ENV["COVERAGE"] == "1"
   require "simplecov"
   SimpleCov.start do
     enable_coverage :branch

--- a/test/section_test.rb
+++ b/test/section_test.rb
@@ -40,8 +40,8 @@ comment
   end
 
   test "parses word phrases as styleguide references" do
-    @comment_text.gsub!('2.1.1', 'Buttons - Truly Lime')
-    section = Kss::Section.new(@comment_text, 'example.css')
+    text = @comment_text.gsub('2.1.1', 'Buttons - Truly Lime')
+    @section = Kss::Section.new(text, 'example.css')
     assert_equal 'Buttons - Truly Lime', @section.section
   end
 


### PR DESCRIPTION
## Summary

- **Ruby 3.2+ compat**: replace removed `File.exists?`/`Dir.exists?` with `exist?`
- **Multi-version Docker CI**: Dockerized test matrix covering Ruby 1.9–4.0 + head, replacing Travis CI
  - `Dockerfile` compiles Ruby from source with appropriate OpenSSL (1.0.2 for <2.4, 1.1 for ≥2.4)
  - `Dockerfile.head` builds ruby/ruby master
  - `docker-bake.hcl` defines all 16 build targets
  - GitHub Actions workflow with per-version matrix jobs and a gate job
  - `test-all-rubies.sh` for local parallel testing via GNU parallel
- **Bundler 1.x/2.x compat**: Dockerfile falls back to `bundle config --local` for Bundler 1.17.3
- **Gemfile modernization**: version-gated minitest (5.x/6.x), rake (12.x/13.x), test-unit
- **SimpleCov code coverage**: gated on `COVERAGE=1` env var, enabled only for Ruby 4.0 in CI
  - Line coverage: 98.71%, branch coverage: 78.85%
- **Misc cleanup**: remove deprecated `has_rdoc`, remove unused `mg`/`rubyforge` gems, fix `gsub` mutation warning in tests

## Test plan

- [x] All 16 Ruby versions pass locally via `test-all-rubies.sh`
- [x] SimpleCov runs only on Ruby 4.0, other versions unaffected
- [x] CI passes on GitHub Actions in forked repo (djbender/kss)
